### PR TITLE
Update test-group-by.R

### DIFF
--- a/tests/testthat/test-group-by.R
+++ b/tests/testthat/test-group-by.R
@@ -75,6 +75,6 @@ with_mock_crunch({
     })
     test_that("Grouping helpers work on CrunchDatasets", {
         expect_null(group_vars(ds))
-        expect_identical(tbl_vars(ds), names(ds))
+        expect_identical(as.character(tbl_vars(ds)), names(ds))
     })
 })


### PR DESCRIPTION
adapt test since `tbl_vars()` will return a more structured object in dplyr > 0.8.2

This was making this package fail when checking dplyr's reverse dependencies. More on this here: https://github.com/tidyverse/dplyr/pull/4399